### PR TITLE
Fatal error occurs with the --environment argument

### DIFF
--- a/rancher_gitlab_deploy/cli.py
+++ b/rancher_gitlab_deploy/cli.py
@@ -59,7 +59,7 @@ def main(rancher_url, rancher_key, rancher_secret, environment, stack, service, 
         for e in environments:
             if e['id'].lower() == environment.lower() or e['name'].lower() == environment.lower():
                 environment_id = e['id']
-                environment_name = environment[0]['name']
+                environment_name = e['name']
 
     if not environment_id:
         if environment:


### PR DESCRIPTION
When you use the --environment command line argument the script tries to read the environment as if it was an array (seemingly a copy paste issue from line 57). This change will read the name from the correct variable
