### PR TITLE
Ability to change sidekicks images when upgrading a service

### DIFF
--- a/rancher_gitlab_deploy/cli.py
+++ b/rancher_gitlab_deploy/cli.py
@@ -35,7 +35,9 @@ from time import sleep
               help="Mark the upgrade as finished after it completes")
 @click.option('--sidekicks/--no-sidekicks', default=False,
               help="Upgrade also service sidekicks")
-def main(rancher_url, rancher_key, rancher_secret, environment, stack, service, new_image, batch_size, batch_interval, start_before_stopping, upgrade_timeout, wait_for_upgrade_to_finish, finish_upgrade, sidekicks):
+@click.option('--new-sidekick-image', default=None, multiple=True,
+              help="If specified, replace the image (and :tag) with this one during the upgrade", type=(str, str))
+def main(rancher_url, rancher_key, rancher_secret, environment, stack, service, new_image, batch_size, batch_interval, start_before_stopping, upgrade_timeout, wait_for_upgrade_to_finish, finish_upgrade, sidekicks, new_sidekick_image):
     """Performs an in service upgrade of the service specified on the command line"""
     # split url to protocol and host
     if "://" not in rancher_url:
@@ -153,6 +155,7 @@ def main(rancher_url, rancher_key, rancher_secret, environment, stack, service, 
     }}
     # copy over the existing config
     upgrade['inServiceStrategy']['launchConfig'] = service['launchConfig']
+    upgrade['inServiceStrategy']['secondaryLaunchConfigs'] = service['secondaryLaunchConfigs']
 
     if sidekicks:
         # copy over existing sidekicks config
@@ -161,6 +164,13 @@ def main(rancher_url, rancher_key, rancher_secret, environment, stack, service, 
     if new_image:
         # place new image into config
         upgrade['inServiceStrategy']['launchConfig']['imageUuid'] = 'docker:%s' % new_image
+
+    if new_sidekick_image:
+        new_sidekick_image = dict(new_sidekick_image)
+        
+        for idx, secondaryLaunchConfigs in enumerate(service['secondaryLaunchConfigs']):
+            if secondaryLaunchConfigs['name'] in new_sidekick_image:
+                upgrade['inServiceStrategy']['secondaryLaunchConfigs'][idx]['imageUuid'] = 'docker:%s' % new_sidekick_image[secondaryLaunchConfigs['name']]
 
     # 5 -> Start the upgrade
 


### PR DESCRIPTION
Add --new-sidekick-image to change a sidekick image when upgrading a service #9 

The option can be passed multiple times in a command (in the case where you have multiple sidekicks per service), and accept a tuple(sidekickName, newImage).

Example:
`rancher-gitlab-deploy ... --new-sidekick-image sidekick1 registry.fakename.com:5000/code:v0.0.2 --new-sidekick-image sidekick2 registry.fakename.com:5000/assets:v0.0.2`