### PR TITLE
Fix secondary config (sidekicks) by default must be empty

### DIFF
--- a/rancher_gitlab_deploy/cli.py
+++ b/rancher_gitlab_deploy/cli.py
@@ -156,7 +156,6 @@ def main(rancher_url, rancher_key, rancher_secret, environment, stack, service, 
     }}
     # copy over the existing config
     upgrade['inServiceStrategy']['launchConfig'] = service['launchConfig']
-    upgrade['inServiceStrategy']['secondaryLaunchConfigs'] = service['secondaryLaunchConfigs']
 
     if sidekicks:
         # copy over existing sidekicks config


### PR DESCRIPTION
Sidekicks are always recreated, even with "--no-sidekicks", I don't know Python well, but I guess this is the right line.