### PR TITLE
Allow labels to be created with the service

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,8 @@ Options:
   --create / --no-create          Will create the Rancher stack
                                   and service, if they are missed
                                   (needs --new-image option)
+  --labels                        Will add Rancher labels to the service being
+                                  created by passing a comma separated list.
   --help                          Show this message and exit.
 
 ```


### PR DESCRIPTION
I've been trying out Rancher the past week or so and this was an awesome
find. I've since learn't that for my set up to work I need to add labels
in order for my load balancer (traefik) to recognise my containers.

As my CI/CD pipeline is dev => gitlab => rancher, I found it pointless
setting this up only to have to add the labels manually.

This fixes that, so now I am able to build review branches on the fly
without having to push my commits, wait for the tests, docker build,
docker push and hit the Rancher API for me to then manually add the
labels.

Please be aware this is the first bit of python code I've ever written, so please let me know if there are any changes you want me to make.