### PR TITLE
Rollback on failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,10 @@ Options:
   --wait-for-upgrade-to-finish / --no-wait-for-upgrade-to-finish
                                   Wait for Rancher to finish the upgrade
                                   before this tool exits
+  --rollback-on-error/--no-rollback-on-error
+                                  Rollback the upgrade if an error occured. 
+                                  The rollback will be performed only 
+                                  if the option --wait-for-upgrade-to-finish is passed
   --new-image TEXT                If specified, replace the image (and :tag)
                                   with this one during the upgrade
   --finish-upgrade / --no-finish-upgrade


### PR DESCRIPTION
Added support to rollback service if the upgrade failed.

The rollback will be done if you pass the option --rollback-on-error with --wait-for-upgrade-to-finish.

After the rollback, the program ends with code 1 to be sure that our CI job fails.

Just share if you have any suggestions to improve the feature 👍 