### PR TITLE
Add '--label', '--variables' and '--variable' options to control Rancher labels and environment variables.

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,16 @@ Options:
                                   (needs --new-image option)
   --labels                        Will add Rancher labels to the service being
                                   created by passing a comma separated list.
+  --label KEY VALUE               Alternative way of adding a Rancher label to the
+                                  service.
+                                  You can pass this option multiple times to create
+                                  multiple labels.
+  --variables                     Will add environment variables to the service being
+                                  created by passing a comma separated list.
+  --variable KEY VALUE            Alternative way of adding environment variables to the
+                                  service.
+                                  You can pass this option multiple times to create
+                                  multiple labels.
   --help                          Show this message and exit.
 
 ```

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Options:
   --variable KEY VALUE            Alternative way of adding environment variables to the
                                   service.
                                   You can pass this option multiple times to create
-                                  multiple labels.
+                                  multiple environment variables.
   --help                          Show this message and exit.
 
 ```


### PR DESCRIPTION
* added ` --label KEY VALUE ` option
* added ` --variables ` option (same syntax as --labels)
* added ` --variable KEY VALUE ` option
* moved the parsing of label/labels and variable/variables option to the start of the main function to allow setting those in service creation as well as service upgrade routines
* parsed labels and variables will be added or even replaced when the services gets upgraded