### PR TITLE
Add support for secrets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 FROM python:2.7-alpine
-ADD . /rancher-gitlab-deploy
+
+COPY . /rancher-gitlab-deploy/
+
 WORKDIR /rancher-gitlab-deploy
 RUN python /rancher-gitlab-deploy/setup.py install
 RUN ln -s /usr/local/bin/rancher-gitlab-deploy /usr/local/bin/upgrade
-CMD rancher-gitlab-deploy
+
+CMD [ "/usr/local/bin/upgrade" ]


### PR DESCRIPTION
Add options for specifying references to *existing* (the code doesn't create/update them) rancher secrets (tested against rancher v1.6.x) 

`--secret SECRET_ID`, `--secrets SECRET_ID1,SECRET_ID2`...

this patch requires support for the `/v2-beta` endpoint in the rancher server and has only been tested against rancher `v1.6.21` (current version we have deployed in production)

I have also slightly changed the Dockerfile to make it pass `hadolint` checks - required in our production pipelines...