### PR TITLE
Allow ability to pass separator for `label`;

### DIFF
--- a/rancher_gitlab_deploy/cli.py
+++ b/rancher_gitlab_deploy/cli.py
@@ -21,6 +21,7 @@ from time import sleep
               help="The environment or account API key")
 @click.option('--rancher-secret', envvar='RANCHER_SECRET_KEY', required=True,
               help="The secret for the access API key")
+@click.option('--rancher-label-separator', envvar='RANCHER_LABEL_SEPARATOR', required=False, default=',', help="Where the default separator (',') could cause issues")
 @click.option('--environment', default=None,
               help="The name of the environment to add the host into " + \
                    "(only needed if you are using an account API key instead of an environment API key)")
@@ -66,7 +67,7 @@ from time import sleep
               help="Enable HTTP Debugging")
 @click.option('--ssl-verify/--no-ssl-verify', default=True,
               help="Disable certificate checks. Use this to allow connecting to a HTTPS Rancher server using an self-signed certificate")
-def main(rancher_url, rancher_key, rancher_secret, environment, stack, service, new_image, batch_size, batch_interval, start_before_stopping, upgrade_timeout, wait_for_upgrade_to_finish, rollback_on_error, finish_upgrade, sidekicks, new_sidekick_image, create, labels, label, variables, variable, service_links, service_link, debug, ssl_verify):
+def main(rancher_url, rancher_key, rancher_secret, rancher_label_separator, environment, stack, service, new_image, batch_size, batch_interval, start_before_stopping, upgrade_timeout, wait_for_upgrade_to_finish, rollback_on_error, finish_upgrade, sidekicks, new_sidekick_image, create, labels, label, variables, variable, service_links, service_link, debug, ssl_verify):
     """Performs an in service upgrade of the service specified on the command line"""
 
     if debug:
@@ -93,7 +94,7 @@ def main(rancher_url, rancher_key, rancher_secret, environment, stack, service, 
     defined_labels = {}
 
     if labels is not None:
-        labels_as_array = labels.split(',')
+        labels_as_array = labels.split(rancher_label_separator)
 
         for label_item in labels_as_array:
             key, value = label_item.split('=', 1)


### PR DESCRIPTION
Allows for the user to pass `RANCHER_LABEL_SEPARATOR` to override the default `,` separator.

[Ticket](https://github.com/cdrx/rancher-gitlab-deploy/issues/64)