### PR TITLE
Trim env. variable names and values; support trailing comma (#71)

### DIFF
--- a/rancher_gitlab_deploy/cli.py
+++ b/rancher_gitlab_deploy/cli.py
@@ -239,8 +239,14 @@ def main(
         labels_as_array = labels.split(rancher_label_separator)
 
         for label_item in labels_as_array:
-            key, value = label_item.split("=", 1)
-            defined_labels[key] = value
+            label_item = label_item.strip()
+
+            if label_item:
+                key, value = label_item.split("=", 1)
+                key = key.strip()
+                value = value.strip()
+
+                defined_labels[key] = value
 
     if label:
         for item in label:
@@ -280,7 +286,7 @@ def main(
             if secret_item:
                 key, value = secret_item.split("=", 1)
                 key = key.strip()
-                
+
                 defined_secrets.append({"type": "secretReference", "name": key})
 
     if secret:

--- a/rancher_gitlab_deploy/cli.py
+++ b/rancher_gitlab_deploy/cli.py
@@ -254,8 +254,14 @@ def main(
         variables_as_array = variables.split(",")
 
         for variable_item in variables_as_array:
-            key, value = variable_item.split("=", 1)
-            defined_environment_variables[key] = value
+            variable_item = variable_item.strip()
+
+            if variable_item:
+                key, value = variable_item.split("=", 1)
+                key = key.strip()
+                value = value.strip()
+
+                defined_environment_variables[key] = value
 
     if variable:
         for item in variable:
@@ -269,8 +275,13 @@ def main(
         secrets_as_array = secrets.split(",")
 
         for secret_item in secrets_as_array:
-            key, value = secret_item.split("=", 1)
-            defined_secrets.append({"type": "secretReference", "name": key})
+            secret_item = secret_item.strip()
+
+            if secret_item:
+                key, value = secret_item.split("=", 1)
+                key = key.strip()
+                
+                defined_secrets.append({"type": "secretReference", "name": key})
 
     if secret:
         for item in secret:


### PR DESCRIPTION
- Trim env. variable names and values when using with `--variables`.
- Trim secret names when using with `--secrets`.
- Add support for trailing comma in `--variables` and `--secrets`.